### PR TITLE
fix: improve multiline string handling

### DIFF
--- a/cue-mode.el
+++ b/cue-mode.el
@@ -95,6 +95,8 @@ For example:
 
 (defun cue-syntax-stringify ()
   "Put `syntax-table' property correctly on single/triple quotes."
+  ;; This function is mostly a copy of the python multi-line string
+  ;; code.
   (let* ((ppss (save-excursion (backward-char 3) (syntax-ppss)))
          (string-start (and (eq t (nth 3 ppss)) (nth 8 ppss)))
          (quote-starting-pos (- (point) 3))
@@ -315,6 +317,7 @@ it should move backward to the beginning of the previous token."
                                       smie-indent-comment-continue
                                       smie-indent-comment-close
                                       smie-indent-comment-inside
+                                      smie-indent-inside-string
                                       smie-indent-keyword
                                       smie-indent-after-keyword
                                       smie-indent-empty-line

--- a/tests/cue-mode-indent-tests.el
+++ b/tests/cue-mode-indent-tests.el
@@ -104,3 +104,21 @@ import (
 	life:  >0
 	nums:  list.MaxItems(10)
 }"))
+
+(ert-deftest cue--test-indent-multiline-string ()
+  "We should not alter multiline strings."
+  (cue--should-indent
+   "
+value: {
+	string: \"\"\"
+	Test multi
+	     line string
+	\"\"\"
+}"
+   "
+value: {
+	string: \"\"\"
+	Test multi
+	     line string
+	\"\"\"
+}"))


### PR DESCRIPTION
Multiline strings were being indented  like regular syntax this meant
that selecting the entire file or a large section and indenting it
would do crazy things to the multiline string content

I'm not sure of the best way to deal with multiline strings, but this
at least seems to stop arbitrary changes happening.

It's still not perfect, as it can't indent the closing quotes correctly.