### PR TITLE
reset default-directory of output buffer on eval

### DIFF
--- a/cue-mode.el
+++ b/cue-mode.el
@@ -357,6 +357,7 @@ it should move backward to the beginning of the previous token."
                         (list file-to-eval))))
       (let ((outbuf (get-buffer-create output-buffer-name)))
         (with-current-buffer outbuf
+          (setq default-directory (file-name-directory file-to-eval))
           (let ((origional-point (point)))
             (setq buffer-read-only nil)
             (erase-buffer)


### PR DESCRIPTION
This will configure the working directory of the 'call-process' function to the
file being evaluated, which is necessary when evaluating CUE files of a
different project that import packages.